### PR TITLE
FEAT:  linter 설치 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+
+dotnet_diagnostic.IDE0051.severity = none
+dotnet_diagnostic.IDE0044.severity = warning

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "▶️ Running dotnet format..."
+
+dotnet format --verify-no-changes > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "❌ 코드 스타일 검사 실패! 포맷팅되지 않은 코드가 있습니다."
+  echo "   아래 명령어로 자동 정리할 수 있습니다:"
+  echo "   dotnet format"
+  exit 1
+fi
+
+echo "✅ 코드 스타일 확인 완료. 커밋 진행합니다."


### PR DESCRIPTION
이 PR은 커밋 시 dotnet-format을 이용해 C# 코드 스타일 검사를 수행하는 pre-commit hook을 추가합니다.
- scripts/pre-commit: lint 스크립트
- .editorconfig: 포맷 기준 설정 파일

아래 명령어로 hook을 설치해야 합니다:

cp scripts/pre-commit .git/hooks/pre-commit
chmod +x .git/hooks/pre-commit

